### PR TITLE
Redirect URI response constructors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10.9.0 as builder
 WORKDIR /auth
 
 ARG SCOPE
-ARG CORTEX_URL
+ARG CORTEX_URL=/cortex
 
 ADD ./ /auth
 

--- a/docker/script.sh
+++ b/docker/script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sed -i /auth/src/ep.config.json -e "s/\"scope\": \"vestri\"/\"scope\": \"$SCOPE\"/g"
-sed -i /auth/src/ep.config.json -e "s/\"pathForProxy\": \"http:\/\/localhost:9080\"/\"pathForProxy\": \"http:\/\/$CORTEX_URL\"/g"
+sed -i /auth/src/ep.config.json -e "s#\"scope\": \"vestri\"#\"scope\": \"$SCOPE\"#g"
+sed -i /auth/src/ep.config.json -e "s#\"path\": \"\/cortex\"#\"path\": \"$CORTEX_URL\"#g"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6236,11 +6236,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6253,15 +6255,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6364,7 +6369,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6374,6 +6380,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6386,17 +6393,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6413,6 +6423,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6485,7 +6496,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6495,6 +6507,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6600,6 +6613,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/containers/AuthenticationPage.jsx
+++ b/src/containers/AuthenticationPage.jsx
@@ -121,22 +121,22 @@ class AuthPage extends React.Component {
               <div className="forgot">
                 <a href="reset.html">Forgot password?</a>
               </div>
-              <button type="submit" className="btn btn-primary" onClick={this.login}>Login</button>
+              {(responder && responder.constructResponseUri) ? (
+                <button type="submit" className="btn btn-primary" onClick={this.login}>Login</button>
+              ) : (
+                <div className="display-block">
+                  <h1 className="color-red">
+                    <span className="glyphicon glyphicon-remove-circle" />
+                    &nbsp;&nbsp; We are unable to log you in at this time
+                  </h1>
+                </div>
+              )}
               <div className="panel margin-top-30">
-                {(responder && responder.constructResponseUri) ? (
-                  <div className={isLogging ? 'display-block' : 'display-none'}>
-                    <h1 className="color-blue">
-                      <span className="glyphicon glyphicon-refresh glyphicon-refresh-animate" />
-                    </h1>
-                  </div>
-                ) : (
-                  <div className="display-block">
-                    <h1 className="color-red">
-                      <span className="glyphicon glyphicon-remove-circle" />
-                      &nbsp;&nbsp; We are unable to log you in at this time
-                    </h1>
-                  </div>
-                )}
+                <div className={isLogging ? 'display-block' : 'display-none'}>
+                  <h1 className="color-blue">
+                    <span className="glyphicon glyphicon-refresh glyphicon-refresh-animate" />
+                  </h1>
+                </div>
                 <div className={succeededLogin ? 'display-block' : 'display-none'}>
                   <h1 className="color-green">
                     <span className="glyphicon glyphicon-ok-circle" />

--- a/src/containers/AuthenticationPage.jsx
+++ b/src/containers/AuthenticationPage.jsx
@@ -97,7 +97,12 @@ class AuthPage extends React.Component {
   }
 
   render() {
-    const { isLogging, failedLogin, succeededLogin } = this.state;
+    const {
+      isLogging,
+      failedLogin,
+      succeededLogin,
+      responder,
+    } = this.state;
     return (
       <div className="col-md-12 col-lg-8 offset-lg-2 col-xl-6 offset-xl-3">
         <div className="facebook-auth-form">
@@ -118,11 +123,20 @@ class AuthPage extends React.Component {
               </div>
               <button type="submit" className="btn btn-primary" onClick={this.login}>Login</button>
               <div className="panel margin-top-30">
-                <div className={isLogging ? 'display-block' : 'display-none'}>
-                  <h1 className="color-blue">
-                    <span className="glyphicon glyphicon-refresh glyphicon-refresh-animate" />
-                  </h1>
-                </div>
+                {(responder && responder.constructResponseUri) ? (
+                  <div className={isLogging ? 'display-block' : 'display-none'}>
+                    <h1 className="color-blue">
+                      <span className="glyphicon glyphicon-refresh glyphicon-refresh-animate" />
+                    </h1>
+                  </div>
+                ) : (
+                  <div className="display-block">
+                    <h1 className="color-red">
+                      <span className="glyphicon glyphicon-remove-circle" />
+                      &nbsp;&nbsp; We are unable to log you in at this time
+                    </h1>
+                  </div>
+                )}
                 <div className={succeededLogin ? 'display-block' : 'display-none'}>
                   <h1 className="color-green">
                     <span className="glyphicon glyphicon-ok-circle" />

--- a/src/containers/AuthenticationPage.jsx
+++ b/src/containers/AuthenticationPage.jsx
@@ -22,6 +22,7 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { loginRegistered } from '../utils/AuthService';
+import { findResponder } from '../responders';
 import './AuthenticationPage.less';
 
 class AuthPage extends React.Component {
@@ -32,18 +33,15 @@ class AuthPage extends React.Component {
   constructor(props) {
     super(props);
     const params = new URLSearchParams(props.location.search);
-    const redirectUri = params.get('redirect_uri');
-    const authState = params.get('state');
     this.state = {
       email: '',
       password: '',
       isLogging: false,
       failedLogin: '',
       succeededLogin: '',
-      redirectUri,
-      authState,
+      params,
     };
-
+    this.state.responder = findResponder(this.state);
     this.setPassword = this.setPassword.bind(this);
     this.setEmail = this.setEmail.bind(this);
     this.login = this.login.bind(this);
@@ -58,9 +56,7 @@ class AuthPage extends React.Component {
   }
 
   login() {
-    const {
-      email, password, redirectUri, authState,
-    } = this.state;
+    const { email, password, responder } = this.state;
 
     this.setState({
       isLogging: true,
@@ -76,7 +72,7 @@ class AuthPage extends React.Component {
           isLogging: false,
         });
         setTimeout(() => {
-          window.location = `${redirectUri}#state=${authState}&access_token=${response}&token_type=Bearer`;
+          window.location = responder.constructResponseUri(this.state, response.json().access_token);
         }, 3000);
       } else if (response.status === 400 || response.status === 401) {
         this.setState({

--- a/src/containers/AuthenticationPage.jsx
+++ b/src/containers/AuthenticationPage.jsx
@@ -22,7 +22,7 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { loginRegistered } from '../utils/AuthService';
-import { findResponder } from '../responders';
+import findResponder from '../responders';
 import './AuthenticationPage.less';
 
 class AuthPage extends React.Component {

--- a/src/containers/AuthenticationPage.jsx
+++ b/src/containers/AuthenticationPage.jsx
@@ -71,9 +71,11 @@ class AuthPage extends React.Component {
           succeededLogin: 'You successfully logged in!',
           isLogging: false,
         });
-        setTimeout(() => {
-          window.location = responder.constructResponseUri(this.state, response.json().access_token);
-        }, 3000);
+        response.json().then((json) => {
+          setTimeout(() => {
+            window.location = responder.constructResponseUri(this.state, json.access_token);
+          }, 3000);
+        });
       } else if (response.status === 400 || response.status === 401) {
         this.setState({
           failedLogin: 'The email address or the password is incorrect',

--- a/src/containers/AuthenticationPage.jsx
+++ b/src/containers/AuthenticationPage.jsx
@@ -65,7 +65,7 @@ class AuthPage extends React.Component {
     });
 
     loginRegistered(email, password).then((response) => {
-      if (response.status >= 200 && response.status < 300) {
+      if (response.status >= 200 && response.status < 300 && responder && responder.constructResponseUri) {
         this.setState({
           failedLogin: '',
           succeededLogin: 'You successfully logged in!',

--- a/src/responders.js
+++ b/src/responders.js
@@ -22,7 +22,7 @@
 import AlexaResponder from './responders/alexa';
 
 const responders = [
-  new AlexaResponder(),
+  AlexaResponder,
 ];
 
 export default function findResponder(params) {

--- a/src/responders.js
+++ b/src/responders.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2018 Elastic Path Software Inc. All rights reserved.
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this license. If not, see
+ *
+ *     https://www.gnu.org/licenses/
+ *
+ *
+ */
+
+import { AlexaResponder } from './responders/alexa';
+
+const responders = [
+   new AlexaResponder()
+];
+
+
+export function findResponder(params) {
+   for (const responder of responders) {
+       if (responder.canRespond(params)) {
+           return responder;
+       }
+   }
+   return null;
+}

--- a/src/responders.js
+++ b/src/responders.js
@@ -19,18 +19,13 @@
  *
  */
 
-import { AlexaResponder } from './responders/alexa';
+import AlexaResponder from './responders/alexa';
 
 const responders = [
-   new AlexaResponder()
+  new AlexaResponder(),
 ];
 
-
-export function findResponder(params) {
-   for (const responder of responders) {
-       if (responder.canRespond(params)) {
-           return responder;
-       }
-   }
-   return null;
+export default function findResponder(params) {
+  const validResponders = responders.filter(responder => responder.canRespond && responder.canRespond(params));
+  return (validResponders.length > 0) ? validResponders[0] : null;
 }

--- a/src/responders/alexa.js
+++ b/src/responders/alexa.js
@@ -19,20 +19,20 @@
  *
  */
 
-const matcher =  /^https:\/\/([A-Za-z0-9])+\.amazon.com\/spa\/skill\/account-linking-status\.html/;
+const matcher = /^https:\/\/([A-Za-z0-9])+\.amazon.com\/spa\/skill\/account-linking-status\.html/;
 
- class AlexaResponder {
-    canRespond(state) {
-        const { params } = state;
-        return params && params.has('redirect_uri') && params.has('state') && matcher.test(params.get('redirect_uri'));
-    }
+class AlexaResponder {
+  static canRespond(state) {
+    const { params } = state;
+    return params && params.has('redirect_uri') && params.has('state') && matcher.test(params.get('redirect_uri'));
+  }
 
-    constructResponseUri(state, token) {
-        const { params } = state;
-        const redirect_uri = params.get('redirect_uri');
-        const aws_state = params.get('state');
-        return `${redirect_uri}#state=${aws_state}&access_token=${token}&token_type=Bearer`
-    }
- }
+  static constructResponseUri(state, token) {
+    const { params } = state;
+    const redirectUri = params.get('redirect_uri');
+    const awsState = params.get('state');
+    return `${redirectUri}#state=${awsState}&access_token=${token}&token_type=Bearer`;
+  }
+}
 
- export default AlexaResponder;
+export default AlexaResponder;

--- a/src/responders/alexa.js
+++ b/src/responders/alexa.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2018 Elastic Path Software Inc. All rights reserved.
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this license. If not, see
+ *
+ *     https://www.gnu.org/licenses/
+ *
+ *
+ */
+
+const matcher =  /^https:\/\/([A-Za-z0-9])+\.amazon.com\/spa\/skill\/account-linking-status\.html/;
+
+ class AlexaResponder {
+    canRespond(state) {
+        const { params } = state;
+        return params && params.has('redirect_uri') && params.has('state') && matcher.test(params.get('redirect_uri'));
+    }
+
+    constructResponseUri(state, token) {
+        const { params } = state;
+        const redirect_uri = params.get('redirect_uri');
+        const aws_state = params.get('state');
+        return `${redirect_uri}#state=${aws_state}&access_token=${token}&token_type=Bearer`
+    }
+ }
+
+ export default AlexaResponder;

--- a/src/responders/facebookchatbot.js
+++ b/src/responders/facebookchatbot.js
@@ -19,15 +19,19 @@
  *
  */
 
-import AlexaResponder from './responders/alexa';
-import FacebookChatbotResponder from './responders/facebookchatbot';
+const matcher = /^https:\/\/facebook.com\/messenger_platform\/account_linking/;
 
-const responders = [
-  AlexaResponder,
-  FacebookChatbotResponder,
-];
+class FacebookChatbotResponder {
+  static canRespond(state) {
+    const { params } = state;
+    return params && params.has('redirect_uri') && matcher.test(params.get('redirect_uri'));
+  }
 
-export default function findResponder(params) {
-  const validResponders = responders.filter(responder => responder.canRespond && responder.canRespond(params));
-  return (validResponders.length > 0) ? validResponders[0] : null;
+  static constructResponseUri(state, token) {
+    const { params } = state;
+    const redirectUri = params.get('redirect_uri');
+    return `${redirectUri}&authorization_code=${token}`;
+  }
 }
+
+export default FacebookChatbotResponder;

--- a/src/utils/AuthService.js
+++ b/src/utils/AuthService.js
@@ -56,13 +56,12 @@ export function loginRegistered(username, password) {
         Authorization: localStorage.getItem(`${Config.cortexApi.scope}_oAuthToken`),
       },
       body: userFormBodyString,
-    }).then((res) => {
-      resolve(res);
-    }).catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error(error.message);
-      reject(error);
-    });
+    }).then(res => resolve(res))
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error(error.message);
+        reject(error);
+      });
   }));
 }
 

--- a/src/utils/AuthService.js
+++ b/src/utils/AuthService.js
@@ -57,7 +57,7 @@ export function loginRegistered(username, password) {
       },
       body: userFormBodyString,
     }).then((res) => {
-      resolve(res)
+      resolve(res);
     }).catch((error) => {
       // eslint-disable-next-line no-console
       console.error(error.message);

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -30,7 +30,6 @@ const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
 });
 
 const WorkboxPlugin = require('workbox-webpack-plugin');
-const WebpackPwaManifest = require('webpack-pwa-manifest');
 const AppCachePlugin = require('appcache-webpack-plugin');
 const epConfig = require('../src/ep.config.json');
 


### PR DESCRIPTION
Description:
Added different handlers for constructing the correct redirects to different services that the reference experience is linking accounts.  Based on component state, the account linking server should be able to function properly for any Implicit Grant.

Linting:
- [x] No linting errors

Tests:
- [x] Manual tests
I have tested the authentication/re-authentication process through the Alexa skill.  I am blocked a little but on FB at the moment but I am coordinating with @CPinelli on how we can test this. 

Documentation:
- [x] Requires documentation updates
Oh heck yes