### PR TITLE
Account linking accessible on root /

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,7 +40,7 @@ const Root = () => [
 
 const App = withRouter(Root);
 const AppWithRouter = () => (
-  <Router basename="/auth/">
+  <Router basename="/">
     <App />
   </Router>
 );

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -40,7 +40,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'), // directory for output files
     filename: '[name].js', // using [name] will create a bundle with same file name as source
-    publicPath: '/auth',
+    publicPath: '/',
   },
   module: {
     rules: [


### PR DESCRIPTION
Description:
This change update account linking so that it runs on root `/`, instead of `/auth`. The reason being, when deployed via docker, navigating to `/auth` would result in a 500 error, navigating to `/` loads index.html but not the auth form component.
Tthis behaviour doesn't happen when running `npm start` locally)
When checking logs, this error message appears:
```
[error] 6#6: *281 rewrite or internal redirection cycle while internally redirecting to "/auth/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html"

By changing it to run on root, we can have the account linking webapp run on port 9000 and it would not be broken when running on the docker container.
```
Jira Ticket: `https://jira.elasticpath.com/browse/DBT-207`


Linting:
<!--Have you validated that no linting errors are introduced? -->
- [x] No linting errors

Tests:
<!--Have tests been run locally and passed? If manual tests run, explain what was run below-->
- [x] Manual tests
- Built docker image locally and ran the container, confirmed can access account linking page from localhost:9000
- ran `npm run build` and put the resulted dist into a s3 bucket to be served. 

Documentation:
<!--Are documentation updates required? Include any mention of updates required below if necessary-->
- [x] Requires documentation updates
Would mean all mentions of `localhost:9000/auth` need to be changed to `localhost:9000` in `Reference Experiences - Login Server Documentation`